### PR TITLE
include model fixed parameters in sample_lhs result

### DIFF
--- a/rhodium/sampling.py
+++ b/rhodium/sampling.py
@@ -51,7 +51,11 @@ def sample_lhs(model, nsamples):
         
         for key, values in six.iteritems(samples):
             entry[key] = values[i]
-    
+            
+        # include model fixed parameters
+        for key in model.fixed_parameters.keys():
+            entry[key] = model.fixed_parameters[key]
+
         result.append(entry)
         
     return result


### PR DESCRIPTION
@dhadka: I've been using `fixed_parameters` to pass in Model parameters that are constant (but may change between experiments). For instance,

```
model.fixed_parameters.update({
    "constant_param1": 2045, 
    "constant_param2": 20
})
```
However, I run into problems evaluating the SOWs generated by `sample_lhs()`, since `fixed_parameters` aren't included in it and the model still expects these as parameters. I figured instead of running this each time:

```
SOWs = sample_lhs(model, 10)
results1 = evaluate(model, update(SOWs, {"constant_param1": 2045, "constant_param2":20}) )
results2 = evaluate(model, update(SOWs, {"constant_param1": 2050, "constant_param2":15}) )
```
could we have `sample_lhs` automatically pass along the constants in the SOWs? Are there cases when we wouldn't want this to happen?