### PR TITLE
Can't have unicode field names in np recarrays

### DIFF
--- a/rhodium/classification.py
+++ b/rhodium/classification.py
@@ -77,6 +77,9 @@ class Cart(object):
         else:
             x = pd.DataFrame(x).to_records(index=False)
             
+        # Convert names to str since numpy chokes on unicode field names
+        x.dtype.names = map(str, x.dtype.names)
+
         # if y is a string or function, compute the actual response value
         # otherwise, ensure y is a numpy matrix/array
         if isinstance(y, six.string_types):

--- a/rhodium/sa.py
+++ b/rhodium/sa.py
@@ -450,7 +450,7 @@ def oat(model, response, policy={}, nsamples=100, **kwargs):
 
     minv = np.nanmin(responses, axis=0)
     maxv = np.nanmax(responses, axis=0)
-    midv = responses[nsamples/2]
+    midv = responses[int(nsamples/2)]     # guard against "real division" producing a float
     
     total_range = maxv-minv
     negative_percentage = abs(midv - minv) / total_range


### PR DESCRIPTION
1. Force recarray field names to `str` since numpy can't handle unicode. 
2. Guard against "real" division producing a float array index.