### PR TITLE
Add triangular distribution and related tests.

### DIFF
--- a/rhodium/model.py
+++ b/rhodium/model.py
@@ -324,6 +324,20 @@ class TriangularUncertainty(Uncertainty):
         return stats.triang.ppf(x, c=self.c, loc=self.min_value, scale=self.scale)
 
 
+class PointUncertainty(Uncertainty):
+    """An uncertainty distribution with all its probability mass at one point on the real line."""
+
+    def __init__(self, name, value):
+        super(PointUncertainty, self).__init__(name)
+        self.value = value
+
+    def levels(self, nlevels):
+        return [self.value] * nlevels
+
+    def ppf(self, x):
+        return self.value
+
+
 class NormalUncertainty(Uncertainty):
     
     def __init__(self, name, mean, stdev, **kwargs):

--- a/rhodium/test/model_test.py
+++ b/rhodium/test/model_test.py
@@ -19,8 +19,11 @@ from __future__ import division, print_function, absolute_import
 
 import six
 import unittest
+import numpy as np
 from rhodium.model import IntegerUncertainty
 from rhodium.model import TriangularUncertainty
+from rhodium.model import PointUncertainty
+
 
 class TestIntegerUncertainty(unittest.TestCase):
     
@@ -70,6 +73,17 @@ class TestTriangularUncertainty(unittest.TestCase):
             tu = TriangularUncertainty('x', 0, 1, 2)
         with self.assertRaises(ValueError):
             tu = TriangularUncertainty('x', 2, 0, 1)
+
+
+class TestPointUncertainty(unittest.TestCase):
+    """Unit tests for PointUncertainty"""
+
+    def test_ppf(self):
+        """Check that the ppf returns the point value for any quantile."""
+        value = 1
+        pu = PointUncertainty('x', value)
+        for quantile in np.linspace(0, 1):
+            self.assertEqual(pu.ppf(quantile), value)
 
 
 if __name__ == '__main__':

--- a/rhodium/test/model_test.py
+++ b/rhodium/test/model_test.py
@@ -20,6 +20,7 @@ from __future__ import division, print_function, absolute_import
 import six
 import unittest
 from rhodium.model import IntegerUncertainty
+from rhodium.model import TriangularUncertainty
 
 class TestIntegerUncertainty(unittest.TestCase):
     
@@ -33,3 +34,43 @@ class TestIntegerUncertainty(unittest.TestCase):
         levels = iu.levels(3)
         self.assertTrue(all(i >= 0 and i <= 10 for i in levels))
         self.assertTrue(all(isinstance(i, six.integer_types) for i in levels))
+
+
+class TestTriangularUncertainty(unittest.TestCase):
+
+    def test_ppf_0_1_symmetric(self):
+        """Check the PPF on a symmetric triangular distribution on (0, 1)."""
+        tu = TriangularUncertainty('x', 0, 1, 0.5)
+
+        self.assertEqual(tu.ppf(0), 0)
+        self.assertEqual(tu.ppf(1), 1)
+        self.assertEqual(tu.ppf(0.5), 0.5)
+
+    def test_ppf_0_1_skew(self):
+        """Check the PPF on a skewed triangular distribution on (0, 1)."""
+        tu = TriangularUncertainty('x', 0, 1, 0.25)
+
+        self.assertEqual(tu.ppf(0), 0)
+        self.assertEqual(tu.ppf(1), 1)
+        self.assertEqual(tu.ppf(0.25), 0.25)
+
+    def test_ppf_10_20_skew(self):
+        """Check the PPF on a skewed triangular distribution on (10, 20)."""
+        tu = TriangularUncertainty('x', 10, 20, 12.5)
+
+        self.assertEqual(tu.ppf(0), 10)
+        self.assertEqual(tu.ppf(1), 20)
+        self.assertEqual(tu.ppf(0.25), 12.5)
+
+    def test_out_of_order(self):
+        """Check that an error is raised if the min, max and mode are not properly ordered."""
+        with self.assertRaises(ValueError):
+            tu = TriangularUncertainty('x', 2, 1, 0)
+        with self.assertRaises(ValueError):
+            tu = TriangularUncertainty('x', 0, 1, 2)
+        with self.assertRaises(ValueError):
+            tu = TriangularUncertainty('x', 2, 0, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add the [triangular distribution](https://en.wikipedia.org/wiki/Triangular_distribution) to the set of available uncertainties.

Example usage of the new feature:
```python
"""Demonstrate new trianguar distribution feature in Rhodium."""

import numpy as np
import matplotlib.pyplot as plt
from scipy import stats
import rhodium as rdm
import seaborn as sns

# Triangular distrib properties
min_value = 0; max_value = 1; mode_value=0.25
scale = max_value - min_value
c = (mode_value - min_value) / scale


def identity(x):
    return x

model = rdm.Model(identity)

model.parameters = [
    rdm.Parameter('x')
]

model.responses = [
    rdm.Response('y'),
]

model.uncertainties = [
    rdm.TriangularUncertainty('x', min_value, max_value, mode_value)
]

scenarios = rdm.sample_lhs(model, nsamples=1000)

sns.distplot(scenarios['x'])

# Plot the pdf
x = np.linspace(min_value, max_value)
density = stats.triang.pdf(x, c=c, scale=scale, loc=min_value)
plt.plot(x, density, linestyle='--', color='black', label='True PDF')

plt.title('Samples from a Triangular Distribution')
plt.xlabel('Value')
plt.ylabel('Density')
plt.legend()
plt.show()
```
![figure_1](https://user-images.githubusercontent.com/3209595/43108068-e62e973c-8ead-11e8-89f8-ce4304f0e8c0.png)
